### PR TITLE
Support for Apigee KVM

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -26,4 +26,5 @@ spec:
             value: "PROD"
         ports:
           - containerPort: 9000
+        imagePullPolicy: Always
       serviceAccount: admin

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	}
 
 	envState := os.Getenv("DEPLOY_STATE")
+
 	switch envState {
 	case "PROD":
 		fmt.Printf("DEPLOY_STATE set to PROD\n")
@@ -39,6 +40,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("Error starting server\n")
 	}
+
 	return
 
 }

--- a/pkg/helper/tokens.go
+++ b/pkg/helper/tokens.go
@@ -1,0 +1,28 @@
+//From Elithrar on StackOverflow
+
+package helper
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+// GenerateRandomBytes returns securely generated random bytes.
+// It will return an error if the system's secure random
+// number generator fails to function correctly, in which
+// case the caller should not continue.
+func GenerateRandomBytes(length int) ([]byte, error) {
+	b := make([]byte, length)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// GenerateRandomString returns a URL-safe, base64 encoded
+// securely generated random string.
+func GenerateRandomString(length int) (string, error) {
+	b, err := GenerateRandomBytes(length)
+	return base64.URLEncoding.EncodeToString(b), err
+}

--- a/pkg/helper/tokens_test.go
+++ b/pkg/helper/tokens_test.go
@@ -1,0 +1,26 @@
+package helper
+
+import (
+	"fmt"
+	"testing"
+)
+
+//Maybe more thorough testing? Unsure how to test random numbers...
+
+func TestGenerateRandomBytes(t *testing.T) {
+	bytes, err := GenerateRandomBytes(32)
+	if err != nil {
+		t.Error("Error from GenerateRandomBytes\n")
+	}
+	fmt.Printf("Got Bytes: %v\n", bytes)
+
+}
+
+func TestGenerateRandomString(t *testing.T) {
+	token, err := GenerateRandomString(32)
+	if err != nil {
+		t.Error("Error from GenerateRandomString\n")
+	}
+	fmt.Printf("Got Token: %v\n", token)
+
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -293,11 +293,12 @@ func createEnvironment(w http.ResponseWriter, r *http.Request) {
 	//Print to console for logging
 	fmt.Printf("Created Secret: %v\n", secret.GetName())
 
-	js, err := json.Marshal(createdNs)
+	js, err := json.Marshal(secret.Data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		fmt.Printf("Error marshalling namespace: %v\n", err)
 	}
+
 	w.WriteHeader(201)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(js)
@@ -418,8 +419,16 @@ func updateEnvironment(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			js, err := json.Marshal(secret.Data)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				fmt.Printf("Error marshalling namespace: %v\n", err)
+			}
+
 			w.WriteHeader(200)
-			fmt.Fprintf(w, "Created Secret: %v\n", secret.GetName())
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(js)
+
 			fmt.Printf("Created Secret: %v\n", secret.GetName())
 
 		} else {
@@ -468,9 +477,17 @@ func updateEnvironment(w http.ResponseWriter, r *http.Request) {
 			fmt.Printf("Error updating secret: %v\n", err)
 		}
 
+		js, err := json.Marshal(secret.Data)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			fmt.Printf("Error marshalling namespace: %v\n", err)
+		}
+
 		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(js)
+
 		fmt.Printf("Updated Secret: %v\n", secret.GetName())
-		fmt.Fprintf(w, "Updated Secret: %v\n", secret.GetName())
 
 	}
 }
@@ -478,9 +495,6 @@ func updateEnvironment(w http.ResponseWriter, r *http.Request) {
 //deleteEnvironment deletes a kubernetes namespace matching the given environmentGroupID and environmentName
 func deleteEnvironment(w http.ResponseWriter, r *http.Request) {
 	pathVars := mux.Vars(r)
-
-	//TODO: Can only delete a namespace based on its name not it's annotations.
-	//Ensure that this is thorough enough for our uses.
 
 	err := client.Namespaces().Delete(pathVars["environmentGroupID"] + "-" + pathVars["environment"])
 	if err != nil {
@@ -531,7 +545,7 @@ func createDeployment(w http.ResponseWriter, r *http.Request) {
 		PublicPaths    string               `json:"publicPaths"`
 		PrivateHosts   string               `json:"privateHosts"`
 		PrivatePaths   string               `json:"privatePaths"`
-		Replicas       int                  `json:"Replicas"`
+		Replicas       int                  `json:"replicas"`
 		PtsURL         string               `json:"ptsURL"`
 		PTS            *api.PodTemplateSpec `json:"pts"`
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Server Test", func() {
 		It("Create Environment", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testenv1","secret": "12345", "hostNames": ["test1"]}`)
+			jsonStr := []byte(`{"environmentName": "testenv1","publicSecret": true, "privateSecret": true, "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -34,7 +34,7 @@ var _ = Describe("Server Test", func() {
 		It("Create Environment with duplicated Host Name", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testenv2","secret": "12345", "hostNames": ["test1"]}`)
+			jsonStr := []byte(`{"environmentName": "testenv2","secret": "12345", "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -47,7 +47,7 @@ var _ = Describe("Server Test", func() {
 		It("Update Environment", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv1", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testenv","secret": "54321"}`)
+			jsonStr := []byte(`{"publicSecret": true, "privateSecret": true, "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -57,12 +57,17 @@ var _ = Describe("Server Test", func() {
 			Expect(resp.StatusCode).Should(Equal(200), "Response should be 200 OK")
 		})
 
+		//TODO: Test secret creation stuff
+
 		It("Create Deployment from PTS URL", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv1/deployments", hostBase)
 
 			jsonStr := []byte(`{
 				"deploymentName": "testdep1",
-    			"trafficHosts": "deploy.k8s.local",
+				"publicHosts": "deploy.k8s.public",
+				"publicPaths": "80:/ 90:/2",
+				"privateHosts": "deploy.k8s.private",
+				"privatePaths": "80:/ 90:/2",
     			"replicas": 1,
     			"ptsURL": "https://api.myjson.com/bins/2aot6"}`)
 
@@ -80,7 +85,6 @@ var _ = Describe("Server Test", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv1/deployments/testdep1", hostBase)
 
 			jsonStr := []byte(`{
-				    "trafficHosts": "deploy.k8s.local",
     				"replicas": 3,
 					"ptsURL": "https://api.myjson.com/bins/2aot6"
 					}`)
@@ -100,11 +104,47 @@ var _ = Describe("Server Test", func() {
 
 			jsonStr := []byte(`{
 				"deploymentName": "testdep2",
-    			"trafficHosts": "deploy.k8s.local",
+ 				"publicHosts": "deploy.k8s.public",
+				"publicPaths": "80:/ 90:/2",
+				"privateHosts": "deploy.k8s.private",
+				"privatePaths": "80:/ 90:/2",
     			"replicas": 1,
 				"ptsURL": "https://api.myjson.com/bins/4nja0",
-				"pts": {"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","labels":{"app":"web2","microservice":"true"},"annotations":{"publicPaths":"80:/ 90:/2"}},"spec":{"containers":[{"name":"nginx","image":"nginx","env":[{"name":"PORT","value":"80"}],"ports":[{"containerPort":80}]},{"name":"test","image":"jbowen/testapp:v0","env":[{"name":"PORT","value":"90"}],"ports":[{"containerPort":90}]}]}}
-					}`)
+				"pts":     
+				{
+					"apiVersion": "v1",
+					"kind": "Pod",
+					"metadata": {
+						"name": "nginx",
+						"labels": {
+							"app": "web"
+						}
+					},
+					"spec": {
+						"containers": [{
+							"name": "nginx",
+							"image": "nginx",
+							"env": [{
+								"name": "PORT",
+								"value": "80"
+							}],
+							"ports": [{
+								"containerPort": 80
+							}]
+						}, {
+							"name": "test",
+							"image": "jbowen/testapp:v0",
+							"env": [{
+								"name": "PORT",
+								"value": "90"
+							}],
+							"ports": [{
+								"containerPort": 90
+							}]
+						}]
+					}
+				}
+			}`)
 
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
@@ -122,8 +162,41 @@ var _ = Describe("Server Test", func() {
 			jsonStr := []byte(`{
 				"trafficHosts": "deploy.k8s.local",
 				"replicas": 3,
-				"pts": {"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","labels":{"app":"web2","microservice":"true"},"annotations":{"publicPaths":"80:/ 90:/2"}},"spec":{"containers":[{"name":"nginx","image":"nginx","env":[{"name":"PORT","value":"80"}],"ports":[{"containerPort":80}]},{"name":"test","image":"jbowen/testapp:v0","env":[{"name":"PORT","value":"90"}],"ports":[{"containerPort":90}]}]}}
-					}`)
+				"pts":     
+				{
+					"apiVersion": "v1",
+					"kind": "Pod",
+					"metadata": {
+						"name": "nginx",
+						"labels": {
+							"app": "web"
+						}
+					},
+					"spec": {
+						"containers": [{
+							"name": "nginx",
+							"image": "nginx",
+							"env": [{
+								"name": "PORT",
+								"value": "80"
+							}],
+							"ports": [{
+								"containerPort": 80
+							}]
+						}, {
+							"name": "test",
+							"image": "jbowen/testapp:v0",
+							"env": [{
+								"name": "PORT",
+								"value": "90"
+							}],
+							"ports": [{
+								"containerPort": 90
+							}]
+						}]
+					}
+				}
+			}`)
 
 			req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonStr))
 
@@ -243,123 +316,3 @@ func setup() (*server.Server, string, error) {
 
 	return testServer, hostBase, nil
 }
-
-/*
-
-//Path: /environmentGroups
-//Method: GET
-func TestGetEnvironmentGroups(t *testing.T) {
-	//This should 404
-
-}
-
-//Path: /environmentGroups/{environmentGroupID
-//Method: GET
-func TestGetEnvironmentGroup(t *testing.T) {
-	//This should 404
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments
-//Method: GET
-func TestGetEnvironments(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments
-//Method: POST
-func TestCreateEnvironment(t *testing.T) {
-	server, hostBase, err := setup()
-	assert.Nil(t, err)
-	t.Logf("Got %v, %v, %v\n", server.Router, hostBase, err)
-
-	url := fmt.Sprintf("%s/environmentGroups/testgroup/environments", hostBase)
-	t.Logf("URL: %v", url)
-
-	client := &http.Client{}
-
-	jsonStr := []byte(`{"environmentName": "testenv","secret": "12345"}`)
-	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonStr))
-
-	assert.Nil(t, err)
-	assert.Equal(t, resp.StatusCode, 201)
-
-	t.Logf("Got Response: %v\n", resp.Body)
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}
-//Method: GET
-func TestGetEnvironment(t *testing.T) {
-	server, hostBase, err := setup()
-	assert.Nil(t, err)
-	t.Logf("Got %v, %v, %v\n", server.Router, hostBase, err)
-
-	url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv", hostBase)
-	t.Logf("URL: %v", url)
-
-	client := &http.Client{}
-
-	resp, err := client.Get(url)
-
-	assert.Nil(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}
-//Method: PATCH
-func TestUpdateEnvironment(t *testing.T) {
-	server, hostBase, err := setup()
-	assert.Nil(t, err)
-	t.Logf("Got %v, %v, %v\n", server.Router, hostBase, err)
-
-	url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv", hostBase)
-	t.Logf("URL: %v", url)
-
-	client := &http.Client{}
-
-	jsonStr := []byte(`{"environmentName": "testenv","secret": "54321"}`)
-	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonStr))
-	// resp, err := client.Update(url, "application/json", bytes.NewBuffer(jsonStr))
-	resp, err := client.Do(req)
-
-	assert.Nil(t, err)
-	assert.Equal(t, resp.StatusCode, 200)
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}
-//Method: DELETE
-func TestDeleteEnvironment(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}/deployments
-//Method: GET
-func TestGetDeployments(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}/deployments
-//Method: POST
-func TestCreateDeployment(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}/deployments/{deployment}
-//Method: GET
-func TestGetDeployment(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}/deployments/{deployment}
-//Method: PATCH
-func TestUpdateDeployment(t *testing.T) {
-
-}
-
-//Path: /environmentGroups/{environmentGroupID}/environments/{environment}/deployments/{deployment}
-//Method: DELETE
-func TestDeleteDeployment(t *testing.T) {
-
-}
-*/

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,11 +2,13 @@ package server_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/30x/enrober/pkg/server"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 
 	. "github.com/onsi/ginkgo"
@@ -18,6 +20,10 @@ var _ = Describe("Server Test", func() {
 
 		client := &http.Client{}
 
+		//Higher scoped secret value
+		var globalPrivate string
+		var globalPublic string
+
 		It("Create Environment", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments", hostBase)
 
@@ -25,8 +31,22 @@ var _ = Describe("Server Test", func() {
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
-
 			Expect(err).Should(BeNil(), "Shouldn't get an error on POST. Error: %v", err)
+
+			tempSecret := api.Secret{
+				Data: make(map[string][]byte),
+			}
+
+			err = json.NewDecoder(resp.Body).Decode(&tempSecret.Data)
+			Expect(err).Should(BeNil(), "Error decoding response: %v", err)
+
+			//Store the private-api-key in higher scope
+			globalPrivate = string(tempSecret.Data["private-api-key"])
+
+			//Store the public-api-key in higher scope
+			globalPublic = string(tempSecret.Data["public-api-key"])
+
+			Expect(tempSecret.Data).ShouldNot(BeNil())
 
 			Expect(resp.StatusCode).Should(Equal(201), "Response should be 201 Created")
 		})
@@ -34,7 +54,7 @@ var _ = Describe("Server Test", func() {
 		It("Create Environment with duplicated Host Name", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testenv2","secret": "12345", "hostNames": ["testhost1"]}`)
+			jsonStr := []byte(`{"environmentName": "testenv2","publicSecret": true, "privateSecret": true, "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -44,20 +64,30 @@ var _ = Describe("Server Test", func() {
 			Expect(resp.StatusCode).Should(Equal(500), "Response should be 500 Internal Server Error")
 		})
 
-		It("Update Environment", func() {
+		It("Update Environment to not change privateSecret", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv1", hostBase)
 
-			jsonStr := []byte(`{"publicSecret": true, "privateSecret": true, "hostNames": ["testhost1"]}`)
+			jsonStr := []byte(`{"publicSecret": true, "privateSecret": false, "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
-
 			Expect(err).Should(BeNil(), "Shouldn't get an error on PATCH. Error: %v", err)
+
+			tempSecret := api.Secret{
+				Data: make(map[string][]byte),
+			}
+
+			err = json.NewDecoder(resp.Body).Decode(&tempSecret.Data)
+			Expect(err).Should(BeNil(), "Error decoding response: %v", err)
+
+			//Make sure that private-api-key wasn't changed
+			Expect(string(tempSecret.Data["private-api-key"])).Should(Equal(globalPrivate))
+
+			//Make sure that public-api-key was changed
+			Expect(string(tempSecret.Data["public-api-key"])).ShouldNot(Equal(globalPublic))
 
 			Expect(resp.StatusCode).Should(Equal(200), "Response should be 200 OK")
 		})
-
-		//TODO: Test secret creation stuff
 
 		It("Create Deployment from PTS URL", func() {
 			url := fmt.Sprintf("%s/environmentGroups/testgroup/environments/testenv1/deployments", hostBase)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -46,17 +46,19 @@ paths:
       - $ref: "#/parameters/environmentGroupIDParam"
       - name: environment_post
         in: body
-        description: Name of environment to be created
+        description: environment JSON body object
         required: true
         schema:
-         description: enivronment JSON body object
          properties: 
           environment_name:
             type: string
             description: Name of environment to be created
-          secret:
-             type: string
-             description: Authentication secret to be created within environment
+          publicSecret:
+             type: boolean
+             description: Set to true if you want a public-api-key secret to be created
+          privateSecret:
+             type: boolean
+             description:  Set to true if you want a private-api-key secret to be created
           hostNames:
             type: array
             items: 
@@ -95,12 +97,22 @@ paths:
       parameters:
       - $ref: "#/parameters/environmentGroupIDParam"
       - $ref: "#/parameters/environmentParam"
-      - name: secret
+      - name: environment_patch
         in: body
-        description: New value of authentication key
-        required: true
+        description: environment JSON body object
+        required: false
         schema: 
-          type: string
+          properties:
+            publicSecret:
+               type: boolean
+               description: Set to true if you want a public-api-key secret to be modified or created
+            privateSecret:
+               type: boolean
+               description:  Set to true if you want a private-api-key secret to be modified or recreated
+            hostNames:
+              type: array
+              items: 
+                type: string
       responses:
         200:
           description: Successful response


### PR DESCRIPTION
`POST` and `PATCH` calls to the environment endpoint will now return the public and private api key values if they exist. This allows a client to parse these values and store then in their Apigee Org KVM.