### PR TITLE
replace hyphen URI delimiter

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,41 +1,86 @@
-hash: 85cd2548a66b84001fbdc5fb6b5d53fcc894d7e4b9d4d1d8f1494dc5487b3354
-updated: 2016-07-25T08:12:05.358191551-06:00
+hash: b937319190a687178773a68deb7a2195ae6ddc315bfa59363620ee833921a293
+updated: 2016-08-10T10:40:45.097427233-06:00
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
 - name: github.com/30x/authsdk
   version: 50e1bb8adac0afdac021b4b08091876d1a70324c
 - name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
   version: 942282e931e8286aa802a30b01fa7e16befb50f3
+- name: github.com/coreos/go-oidc
+  version: 5cf2aa52da8c574d3aa4458f471ad6ae2240fe6b
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
+- name: github.com/coreos/go-systemd
+  version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
+  subpackages:
+  - activation
+  - daemon
+  - dbus
+  - journal
+  - unit
+  - util
+- name: github.com/coreos/pkg
+  version: 7f080b6c11ac2d2347c3cd7521e810207ea1a041
+  subpackages:
+  - capnslog
+  - dlopen
+  - health
+  - httputil
+  - timeutil
 - name: github.com/davecgh/go-spew
-  version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/docker/docker
-  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
-  - pkg/jsonmessage
-  - pkg/mount
-  - pkg/parsers
-  - pkg/symlink
-  - pkg/term
-  - pkg/timeutils
-  - pkg/units
+  - digest
+  - reference
 - name: github.com/docker/go-units
   version: 09dda9d4b0d748c57c14048906d3d094a58ec0c9
 - name: github.com/emicklei/go-restful
-  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
+  version: 7c47e2558a0bbbaba9ecab06bc6681e73028a28a
   subpackages:
-  - swagger
   - log
+  - swagger
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - gogoproto
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/grpc
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
+  - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/plugin
+  - sortkeys
+  - vanity
+  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
@@ -43,24 +88,46 @@ imports:
   subpackages:
   - proto
 - name: github.com/google/cadvisor
-  version: 546a3771589bdb356777c646c6eca24914fdd48b
+  version: 4dbefc9b671b81257973a33211fb12370c1a526e
   subpackages:
   - api
   - cache/memory
   - collector
   - container
+  - container/common
+  - container/docker
+  - container/libcontainer
+  - container/raw
+  - container/rkt
+  - container/systemd
+  - devicemapper
   - events
   - fs
   - healthz
   - http
+  - http/mux
   - info/v1
+  - info/v1/test
   - info/v2
+  - machine
   - manager
+  - manager/watcher
+  - manager/watcher/raw
+  - manager/watcher/rkt
   - metrics
   - pages
+  - pages/static
   - storage
   - summary
   - utils
+  - utils/cloudinfo
+  - utils/cpuload
+  - utils/cpuload/netlink
+  - utils/docker
+  - utils/oomparser
+  - utils/sysfs
+  - utils/sysinfo
+  - utils/tail
   - validate
   - version
 - name: github.com/google/gofuzz
@@ -71,6 +138,8 @@ imports:
   version: 801d6e3b008914ee888c9ab9b1b379b9a56fbf44
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+- name: github.com/jonboulle/clockwork
+  version: 3f831b65b61282ba6bece21b91beea2edc4c887a
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -78,7 +147,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/onsi/ginkgo
-  version: 07d85e6b10c4289c7d612f9b13f45ba36f66d55b
+  version: 2c2e9bb47b4e44067024f29339588cac8b34dd12
   subpackages:
   - ginkgo
   - config
@@ -96,13 +165,14 @@ imports:
   - internal/spec
   - internal/specrunner
 - name: github.com/onsi/gomega
-  version: 8adf9e1730c55cdc590de7d49766cb2acc88d8f2
+  version: 7ce781ea776b2fd506491011353bded2e40c8467
   subpackages:
   - internal/assertion
   - internal/asyncassertion
   - internal/testingtsupport
   - matchers
   - types
+  - internal/oraclematcher
   - format
   - matchers/support/goraph/bipartitegraph
   - matchers/support/goraph/edge
@@ -129,9 +199,10 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: ef7a9a5fb138aa5d3a19988537606226869a0390
+  version: a6ab08426bb262e2d190097751f5cfd1cfdfd17d
   subpackages:
   - expfmt
+  - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
@@ -140,7 +211,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/stretchr/objx
-  version: d40df0cc104c06eae2dfe03d7dddb83802d52f9a
+  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
   version: e3a8ff8ce36581f87a15341206f205b1da467059
   subpackages:
@@ -151,19 +222,38 @@ imports:
   version: f4485b318aadd133842532f841dc205a8e339d74
   subpackages:
   - codec
+  - codec/codecgen
 - name: golang.org/x/net
-  version: c2528b2dd8352441850638a8bb678c2ad056fd3e
+  version: 62685c2d7ca23c807425dca88b11a3e2323dab41
   subpackages:
   - context
+  - context/ctxhttp
   - html
+  - html/atom
   - http2
+  - http2/hpack
   - internal/timeseries
+  - proxy
   - trace
   - websocket
+- name: golang.org/x/oauth2
+  version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
+- name: google.golang.org/cloud
+  version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
+  subpackages:
+  - compute/metadata
+  - internal
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: d466437aa4adc35830964cffc5b5f262c63ddcb4
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: k8s.io/kubernetes
-  version: 5cb86ee022267586db386f62781338b0483733b3
+  version: 283137936a498aed572ee22af6774b6fb6e9fd94
   subpackages:
   - pkg/client/unversioned
   - pkg/client/api
@@ -177,52 +267,71 @@ imports:
   - pkg/api/validation
   - pkg/client/metrics
   - pkg/client/transport
+  - pkg/client/unversioned/clientcmd/api
   - pkg/fields
   - pkg/runtime
-  - pkg/util
+  - pkg/runtime/serializer/streaming
+  - pkg/util/crypto
+  - pkg/util/flowcontrol
   - pkg/util/net
   - pkg/util/sets
   - pkg/version
   - pkg/watch
-  - pkg/watch/json
+  - pkg/watch/versioned
   - pkg/api/meta
+  - pkg/api/meta/metatypes
   - pkg/api/resource
   - pkg/auth/user
   - pkg/conversion
   - pkg/runtime/serializer
   - pkg/types
+  - pkg/util
   - pkg/util/intstr
   - pkg/util/rand
+  - pkg/apis/autoscaling
+  - pkg/apis/batch
   - pkg/api/install
   - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/authentication.k8s.io/install
   - pkg/apis/authorization/install
-  - pkg/apis/autoscaling
   - pkg/apis/autoscaling/install
-  - pkg/apis/batch
   - pkg/apis/batch/install
+  - pkg/apis/batch/v2alpha1
   - pkg/apis/componentconfig/install
   - pkg/apis/extensions/install
-  - pkg/apis/metrics/install
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
   - pkg/client/typed/discovery
   - pkg/util/wait
+  - plugin/pkg/client/auth
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/parsers
   - pkg/api/endpoints
   - pkg/api/pod
   - pkg/api/service
+  - pkg/api/unversioned/validation
   - pkg/api/util
   - pkg/capabilities
   - pkg/util/errors
   - pkg/util/yaml
   - pkg/conversion/queryparams
+  - pkg/util/json
   - pkg/util/integer
   - pkg/util/runtime
   - third_party/forked/reflect
   - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/versioning
   - pkg/apimachinery
+  - pkg/apis/apps/v1alpha1
+  - pkg/apis/authentication.k8s.io
+  - pkg/apis/authentication.k8s.io/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling/v1
@@ -230,12 +339,14 @@ imports:
   - pkg/apis/componentconfig
   - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions/v1beta1
-  - pkg/apis/metrics
-  - pkg/apis/metrics/v1alpha1
+  - pkg/apis/policy/v1alpha1
+  - pkg/apis/rbac/v1alpha1
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
   - pkg/util/hash
   - pkg/util/net/sets
+  - pkg/util/framer
   - pkg/kubelet/qos
   - pkg/master/ports
-- name: speter.net/go/exp/math/dec/inf
-  version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
+  - pkg/kubelet/qos/util
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/30x/enrober
 import:
 - package: k8s.io/kubernetes
-  version: 1.2.0
+  version: 1.3.0
   subpackages:
   - pkg/client/unversioned
   - pkg/client/api

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Server Test", func() {
 		It("Create Environment", func() {
 			url := fmt.Sprintf("%s/environments", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testorg1-testenv1", "hostNames": ["testhost1"]}`)
+			jsonStr := []byte(`{"environmentName": "testorg1:testenv1", "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -65,7 +65,7 @@ var _ = Describe("Server Test", func() {
 		It("Create Environment with duplicated Host Name", func() {
 			url := fmt.Sprintf("%s/environments", hostBase)
 
-			jsonStr := []byte(`{"environmentName": "testorg2-testenv2", "hostNames": ["testhost1"]}`)
+			jsonStr := []byte(`{"environmentName": "testorg2:testenv2", "hostNames": ["testhost1"]}`)
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 
 			resp, err := client.Do(req)
@@ -76,7 +76,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Update Environment", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1", hostBase)
 
 			jsonStr := []byte(`{"hostNames": ["testhost2"]}`)
 			req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonStr))
@@ -99,7 +99,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Create Deployment from PTS URL", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments", hostBase)
 
 			jsonStr := []byte(`{
 				"deploymentName": "testdep1",
@@ -131,7 +131,7 @@ var _ = Describe("Server Test", func() {
 			//Need to wait a little before we run an update
 			//Should look into a better fix
 			time.Sleep(200 * time.Millisecond)
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep1", hostBase)
 
 			jsonStr := []byte(`{
 				"replicas": 3,
@@ -157,7 +157,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Create Deployment from direct PTS", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments", hostBase)
 
 			jsonStr := []byte(`{
 				"deploymentName": "testdep2",
@@ -224,7 +224,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Update Deployment from direct PTS", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep2", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep2", hostBase)
 
 			jsonStr := []byte(`{
 				"trafficHosts": "deploy.k8s.local",
@@ -290,7 +290,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Get Deployment testdep1", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep1", hostBase)
 
 			req, err := http.NewRequest("GET", url, nil)
 
@@ -303,7 +303,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Get Deployment testdep2", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep2", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep2", hostBase)
 
 			req, err := http.NewRequest("GET", url, nil)
 
@@ -316,7 +316,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Get Environment", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1", hostBase)
 
 			req, err := http.NewRequest("GET", url, nil)
 
@@ -328,7 +328,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Delete Deployment testdep1", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep1", hostBase)
 
 			req, err := http.NewRequest("DELETE", url, nil)
 
@@ -341,7 +341,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Delete Deployment testdep2", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1/deployments/testdep2", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1/deployments/testdep2", hostBase)
 
 			req, err := http.NewRequest("DELETE", url, nil)
 
@@ -354,7 +354,7 @@ var _ = Describe("Server Test", func() {
 		})
 
 		It("Delete Environment", func() {
-			url := fmt.Sprintf("%s/environments/testorg1-testenv1", hostBase)
+			url := fmt.Sprintf("%s/environments/testorg1:testenv1", hostBase)
 
 			req, err := http.NewRequest("DELETE", url, nil)
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -23,7 +23,7 @@ type deploymentPost struct {
 	DeploymentName string               `json:"deploymentName"`
 	PublicHosts    *string              `json:"publicHosts,omitempty"`
 	PrivateHosts   *string              `json:"privateHosts,omitempty"`
-	Replicas       int                  `json:"replicas"`
+	Replicas       int32                `json:"replicas"`
 	PtsURL         string               `json:"ptsURL,omitempty"`
 	PTS            *api.PodTemplateSpec `json:"pts,omitempty"`
 	EnvVars        []api.EnvVar         `json:"envVars,omitempty"`
@@ -32,7 +32,7 @@ type deploymentPost struct {
 type deploymentPatch struct {
 	PublicHosts  *string              `json:"publicHosts,omitempty"`
 	PrivateHosts *string              `json:"privateHosts,omitempty"`
-	Replicas     int                  `json:"Replicas"`
+	Replicas     int32                `json:"Replicas"`
 	PtsURL       string               `json:"ptsURL"`
 	PTS          *api.PodTemplateSpec `json:"pts"`
 	EnvVars      []api.EnvVar         `json:"envVars,omitempty"`
@@ -44,7 +44,7 @@ type deploymentResponse struct {
 	PublicPaths     string               `json:"publicPaths,omitempty"`
 	PrivateHosts    string               `json:"privateHosts,omitempty"`
 	PrivatePaths    string               `json:"privatePaths,omitempty"`
-	Replicas        int                  `json:"replicas"`
+	Replicas        int32                `json:"replicas"`
 	Environment     string               `json:"environment"`
 	PodTemplateSpec *api.PodTemplateSpec `json:"podTemplateSpec"`
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -23,7 +23,7 @@ type deploymentPost struct {
 	DeploymentName string               `json:"deploymentName"`
 	PublicHosts    *string              `json:"publicHosts,omitempty"`
 	PrivateHosts   *string              `json:"privateHosts,omitempty"`
-	Replicas       int                  `json:"replicas"`
+	Replicas       int32                `json:"replicas"`
 	PtsURL         string               `json:"ptsURL,omitempty"`
 	PTS            *api.PodTemplateSpec `json:"pts,omitempty"`
 	EnvVars        []api.EnvVar         `json:"envVars,omitempty"`
@@ -32,7 +32,7 @@ type deploymentPost struct {
 type deploymentPatch struct {
 	PublicHosts  *string              `json:"publicHosts,omitempty"`
 	PrivateHosts *string              `json:"privateHosts,omitempty"`
-	Replicas     int                  `json:"Replicas"`
+	Replicas     int32                `json:"Replicas"`
 	PtsURL       string               `json:"ptsURL"`
 	PTS          *api.PodTemplateSpec `json:"pts"`
 	EnvVars      []api.EnvVar         `json:"envVars,omitempty"`

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -23,7 +23,7 @@ type deploymentPost struct {
 	DeploymentName string               `json:"deploymentName"`
 	PublicHosts    *string              `json:"publicHosts,omitempty"`
 	PrivateHosts   *string              `json:"privateHosts,omitempty"`
-	Replicas       int32                `json:"replicas"`
+	Replicas       int                  `json:"replicas"`
 	PtsURL         string               `json:"ptsURL,omitempty"`
 	PTS            *api.PodTemplateSpec `json:"pts,omitempty"`
 	EnvVars        []api.EnvVar         `json:"envVars,omitempty"`
@@ -32,7 +32,7 @@ type deploymentPost struct {
 type deploymentPatch struct {
 	PublicHosts  *string              `json:"publicHosts,omitempty"`
 	PrivateHosts *string              `json:"privateHosts,omitempty"`
-	Replicas     int32                `json:"Replicas"`
+	Replicas     int                  `json:"Replicas"`
 	PtsURL       string               `json:"ptsURL"`
 	PTS          *api.PodTemplateSpec `json:"pts"`
 	EnvVars      []api.EnvVar         `json:"envVars,omitempty"`


### PR DESCRIPTION
Fixes #50 

* replace hyphen delimiter in enrober URIs between `{org}-{env}` with `:`
* fix some` int32` v.` int` type issue...don't know why my compiler caught this?