### PR TITLE
Sync hosts to namespace from Apigee

### DIFF
--- a/pkg/apigee/apigee.go
+++ b/pkg/apigee/apigee.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Default Apigee's api endpoint host
-	DefaultApigeeHost = "https://api.enterprise.apigee.com"
+	DefaultApigeeHost = "https://api.enterprise.apigee.com/"
 
 	// Env Var to set overide default apigee api host
 	EnvVarApigeeHost = "AUTH_API_HOST"
@@ -38,7 +38,7 @@ func (c *Client) Hosts(org, env string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("%s/v1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
+	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHosts: %v", err)
@@ -118,7 +118,7 @@ func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("%s/v1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
+	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHost: %v", err)

--- a/pkg/apigee/apigee.go
+++ b/pkg/apigee/apigee.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Default Apigee's api endpoint host
-	DefaultApigeeHost = "api.enterprise.apigee.com"
+	DefaultApigeeHost = "https://api.enterprise.apigee.com"
 
 	// Env Var to set overide default apigee api host
 	EnvVarApigeeHost = "AUTH_API_HOST"
@@ -38,7 +38,7 @@ func (c *Client) Hosts(org, env string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("https://%s/v1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
+	virtualHostsUrl := fmt.Sprintf("%s/v1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHosts: %v", err)
@@ -52,6 +52,10 @@ func (c *Client) Hosts(org, env string) ([]string, error) {
 		return nil, errors.New(errorMessage)
 	}
 
+	// Response should look like
+	// GET https://api.enterprise.apigee.com/v1/organizations/<org>/environments/test/virtualhosts
+	// > [ "default", "secure" ]
+	
 	virtualHosts := []string{}
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&virtualHosts)
@@ -114,7 +118,7 @@ func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("https://%s/v1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
+	virtualHostsUrl := fmt.Sprintf("%s/v1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHost: %v", err)
@@ -127,6 +131,16 @@ func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
 		errorMessage := fmt.Sprintf("Invalid response status code when getting VirtualHost: Code %d", resp.StatusCode)
 		return nil, errors.New(errorMessage)
 	}
+
+	// Response should look like:
+	// GET https://api.enterprise.apigee.com/v1/organizations/<org>/environments/test/virtualhosts/default
+	// > {
+	//     "hostAliases" : [ "<org>-test.apigee.net" ],
+	//     "interfaces" : [ ],
+	//     "listenOptions" : [ ],
+	//     "name" : "default",
+	//     "port" : "80"
+	//   }
 
 	data := map[string]interface{}{}
 	dec := json.NewDecoder(resp.Body)
@@ -181,27 +195,3 @@ func (c *Client) Get(url string) (*http.Response, error) {
 	
 	return resp, nil
 }
-
-
-//func (c Client) getVirtualHost(org, env, virtualhost string) ([]string, error) {
-//}
-
-
-/*
-
-
- client =: apigee.Client{}
- client.GetHosts(org, env)
-
-GET https://api.enterprise.apigee.com/v1/organizations/adammagaluk1/environments/test/virtualhosts
-> [ "default", "secure" ]
-
-GET https://api.enterprise.apigee.com/v1/organizations/adammagaluk1/environments/test/virtualhosts/default
-> {
-    "hostAliases" : [ "adammagaluk1-test.apigee.net" ],
-    "interfaces" : [ ],
-    "listenOptions" : [ ],
-    "name" : "default",
-    "port" : "80"
-  }
-*/

--- a/pkg/apigee/apigee.go
+++ b/pkg/apigee/apigee.go
@@ -20,13 +20,13 @@ const (
 
 type Client struct {
 	// Authorization token used in the Authorization header on each request
-	token   string
+	Token   string
 	
 	// Apigee api host
-	apigeeApiHost  string
+	ApigeeApiHost  string
 	
 	// Shared httpClient for efficiency
-	httpClient *http.Client
+	HttpClient *http.Client
 }
 
 
@@ -38,7 +38,7 @@ func (c *Client) Hosts(org, env string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
+	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts", c.ApigeeApiHost, org, env)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHosts: %v", err)
@@ -118,7 +118,7 @@ func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
 	hosts := []string{}
 
 	//construct URL
-	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
+	virtualHostsUrl := fmt.Sprintf("%sv1/organizations/%s/environments/%s/virtualhosts/%s", c.ApigeeApiHost, org, env, virtualHost)
 	resp, err := c.Get(virtualHostsUrl)
 	if err != nil {
 		errorMessage := fmt.Sprintf("Failed to make request for VirtualHost: %v", err)
@@ -163,17 +163,17 @@ func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
 
 func (c *Client) initDefaults() {
 	// Init httpClient used by all reqs for efficiency, can be used concurrently
-	if c.httpClient == nil {
-		c.httpClient = &http.Client{}
+	if c.HttpClient == nil {
+		c.HttpClient = &http.Client{}
 	}
 	
 	// If apigee api host is not set configure to defult from env
-	if c.apigeeApiHost == "" {
+	if c.ApigeeApiHost == "" {
 		envVar := os.Getenv(EnvVarApigeeHost)
 		if envVar == "" {
-			c.apigeeApiHost = DefaultApigeeHost
+			c.ApigeeApiHost = DefaultApigeeHost
 		} else {
-			c.apigeeApiHost = envVar
+			c.ApigeeApiHost = envVar
 		}
 	}
 }
@@ -186,9 +186,9 @@ func (c *Client) Get(url string) (*http.Response, error) {
 	}
 
 	//Must pass through the authz header
-	req.Header.Add("Authorization", c.token)
+	req.Header.Add("Authorization", c.Token)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apigee/apigee.go
+++ b/pkg/apigee/apigee.go
@@ -1,0 +1,207 @@
+package apigee
+
+import (
+	"os"
+	"fmt"
+	"errors"
+	"sync"
+
+	"net/http"
+	"encoding/json"
+)
+
+const (
+	// Default Apigee's api endpoint host
+	DefaultApigeeHost = "api.enterprise.apigee.com"
+
+	// Env Var to set overide default apigee api host
+	EnvVarApigeeHost = "AUTH_API_HOST"
+)
+
+type Client struct {
+	// Authorization token used in the Authorization header on each request
+	token   string
+	
+	// Apigee api host
+	apigeeApiHost  string
+	
+	// Shared httpClient for efficiency
+	httpClient *http.Client
+}
+
+
+// Return an array of host strings for the apigee environment
+// - Must first gather VirtualHosts from env and then GET on each VirtualHost
+func (c *Client) Hosts(org, env string) ([]string, error) {
+	c.initDefaults()
+
+	hosts := []string{}
+
+	//construct URL
+	virtualHostsUrl := fmt.Sprintf("https://%s/v1/organizations/%s/environments/%s/virtualhosts", c.apigeeApiHost, org, env)
+	resp, err := c.Get(virtualHostsUrl)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Failed to make request for VirtualHosts: %v", err)
+		return nil, errors.New(errorMessage)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		errorMessage := fmt.Sprintf("Invalid response status code when getting VirtualHosts: Code %d", resp.StatusCode)
+		return nil, errors.New(errorMessage)
+	}
+
+	virtualHosts := []string{}
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&virtualHosts)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Error decoding json response from VirtualHosts: %v", err)
+		return nil, errors.New(errorMessage)
+	}
+
+	// Create a map[string] to store hosts to filter duplicate hosts out
+	tmpHosts := make(map[string]struct{})
+	
+	var wg sync.WaitGroup
+	errChannel := make(chan error, 1)
+	finishedChannel := make(chan bool, 1)
+
+	for _, virtualHost := range virtualHosts {
+		wg.Add(1)
+		go func(virtualHost string) {
+			defer wg.Done()
+			aliases, err := c.hostAliases(org, env, virtualHost)
+			// If error send err to the error channel
+			if err != nil {
+				errChannel <- err
+			}
+			for _, alias := range aliases {
+				// Add to host map to filter out duplicate hosts
+				tmpHosts[alias] = struct{}{}
+			}
+		}(virtualHost)
+	}
+	
+	// Waiting forever is okay because of the blocking select below.
+	// Once gorutine finishes close the finishedChannel
+	go func() {
+		wg.Wait()
+		close(finishedChannel)
+	}()
+
+	// Blocks until either all gorutines are finished or a error occurs
+	select {
+	case <-finishedChannel:
+	case err := <-errChannel:
+		if err != nil {
+			return nil, err
+		}
+	}
+	
+	// Convert map to array strings for return
+	for alias, _ := range tmpHosts {
+		hosts = append(hosts, alias)
+	}
+	
+	return hosts, nil
+}
+
+// Get all hosts from a VirtualHost of an apigee environment
+func (c *Client) hostAliases(org, env, virtualHost string) ([]string, error) {
+	c.initDefaults()
+
+	hosts := []string{}
+
+	//construct URL
+	virtualHostsUrl := fmt.Sprintf("https://%s/v1/organizations/%s/environments/%s/virtualhosts/%s", c.apigeeApiHost, org, env, virtualHost)
+	resp, err := c.Get(virtualHostsUrl)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Failed to make request for VirtualHost: %v", err)
+		return nil, errors.New(errorMessage)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		errorMessage := fmt.Sprintf("Invalid response status code when getting VirtualHost: Code %d", resp.StatusCode)
+		return nil, errors.New(errorMessage)
+	}
+
+	data := map[string]interface{}{}
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&data)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Error decoding json response from VirtualHost: %v", err)
+		return nil, errors.New(errorMessage)
+	}
+
+	if data["hostAliases"] == nil {
+		return nil, errors.New("Missing hostAliases property in the response of VirtualHost")
+	}
+
+	for _, v := range data["hostAliases"].([]interface{}) {
+		hosts = append(hosts, v.(string))
+	}
+
+	return hosts, nil
+}
+
+func (c *Client) initDefaults() {
+	// Init httpClient used by all reqs for efficiency, can be used concurrently
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{}
+	}
+	
+	// If apigee api host is not set configure to defult from env
+	if c.apigeeApiHost == "" {
+		envVar := os.Getenv(EnvVarApigeeHost)
+		if envVar == "" {
+			c.apigeeApiHost = DefaultApigeeHost
+		} else {
+			c.apigeeApiHost = envVar
+		}
+	}
+}
+
+// Make HTTP GET to api server with supplied url, return http.Response
+func (c *Client) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	//Must pass through the authz header
+	req.Header.Add("Authorization", c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	
+	return resp, nil
+}
+
+
+//func (c Client) getVirtualHost(org, env, virtualhost string) ([]string, error) {
+//}
+
+
+/*
+
+
+ client =: apigee.Client{}
+ client.GetHosts(org, env)
+
+GET https://api.enterprise.apigee.com/v1/organizations/adammagaluk1/environments/test/virtualhosts
+> [ "default", "secure" ]
+
+GET https://api.enterprise.apigee.com/v1/organizations/adammagaluk1/environments/test/virtualhosts/default
+> {
+    "hostAliases" : [ "adammagaluk1-test.apigee.net" ],
+    "interfaces" : [ ],
+    "listenOptions" : [ ],
+    "name" : "default",
+    "port" : "80"
+  }
+*/

--- a/pkg/apigee/apigee_test.go
+++ b/pkg/apigee/apigee_test.go
@@ -15,7 +15,7 @@ func TestClientHosts(t *testing.T) {
 	ts := startMockServer()
 	defer ts.Close()
 
-	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	client := Client{ token: "<token>", apigeeApiHost: ts.URL + "/" }
 	hosts, err := client.Hosts("org", "env")
 	if err != nil {
 		t.Fatalf("Error when calling Hosts: %v.", err)
@@ -44,7 +44,7 @@ func TestClienthostAliases(t *testing.T) {
 	ts := startMockServer()
 	defer ts.Close()
 
-	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	client := Client{ token: "<token>", apigeeApiHost: ts.URL + "/" }
 	aliases, err := client.hostAliases("org", "env", "default")
 	if err != nil {
 		t.Fatalf("Error when calling hostAliases: %v.", err)
@@ -66,10 +66,10 @@ func TestClienthostAliases(t *testing.T) {
 // Ensure the apigee api host usees the ENV variable if set.
 func TestClientEnvApiHost(t *testing.T) {
 	resetEnv(t)
-	os.Setenv(EnvVarApigeeHost, "http://some.api.host")
+	os.Setenv(EnvVarApigeeHost, "http://some.api.host/")
 	client := Client{}
 	client.initDefaults()
-	if client.apigeeApiHost != "http://some.api.host" {
+	if client.apigeeApiHost != "http://some.api.host/" {
 		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
 	}
 }
@@ -77,10 +77,10 @@ func TestClientEnvApiHost(t *testing.T) {
 // When apigeeApiHost is supplied when creating the client object it must override the Env variable
 func TestClientParamApiHost(t *testing.T) {
 	resetEnv(t)
-	os.Setenv(EnvVarApigeeHost, "http://some.api.host")
-	client := Client{ apigeeApiHost: "https://some.other.host"}
+	os.Setenv(EnvVarApigeeHost, "http://some.api.host/")
+	client := Client{ apigeeApiHost: "https://some.other.host/"}
 	client.initDefaults()
-	if client.apigeeApiHost != "https://some.other.host" {
+	if client.apigeeApiHost != "https://some.other.host/" {
 		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
 	}
 }

--- a/pkg/apigee/apigee_test.go
+++ b/pkg/apigee/apigee_test.go
@@ -1,0 +1,159 @@
+package apigee
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	
+	"net/http"
+	"net/http/httptest"
+)
+
+// Test Client.Hosts() - It must return all three hosts from "org-env" on both virtual hosts "default" and "secure"
+// Starts a mock http server as the api endpoint.
+func TestClientHosts(t *testing.T) {
+	ts := startMockServer()
+	defer ts.Close()
+
+	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	hosts, err := client.Hosts("org", "env")
+	if err != nil {
+		t.Fatalf("Error when calling Hosts: %v.", err)
+	}
+
+	if len(hosts) != 3 {
+		t.Fatalf("Expected aliases length to be 2 is %d", len(hosts))
+	}
+
+	set := make(map[string]bool)
+	for _, v := range hosts {
+		set[v] = true
+	}
+
+	expectedHosts := []string{"org-env.apigee.net", "api.example.com", "secure.api.example.com"}
+	for _, v := range expectedHosts {
+		if set[v] == false {
+			t.Fatalf("Expected %s in hosts array.", v)
+		}
+	}
+}
+
+// Test Client.hostAliases() - It must return both hosts for the default virtualhost on "org-env"
+// Starts a mock http server as the api endpoint
+func TestClienthostAliases(t *testing.T) {
+	ts := startMockServer()
+	defer ts.Close()
+
+	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	aliases, err := client.hostAliases("org", "env", "default")
+	if err != nil {
+		t.Fatalf("Error when calling hostAliases: %v.", err)
+	}
+
+	if len(aliases) != 2 {
+		t.Fatalf("Expected aliases length to be 2")
+	}
+
+	if aliases[0] != "org-env.apigee.net" {
+		t.Fatalf("Expected first host to be org-env.apigee.net")
+	}
+
+	if aliases[1] != "api.example.com" {
+		t.Fatalf("Expected first host to be api.example.com")
+	}
+}
+
+// Ensure the apigee api host usees the ENV variable if set.
+func TestClientEnvApiHost(t *testing.T) {
+	resetEnv(t)
+	os.Setenv(EnvVarApigeeHost, "http://some.api.host")
+	client := Client{}
+	client.initDefaults()
+	if client.apigeeApiHost != "http://some.api.host" {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	}
+}
+
+// When apigeeApiHost is supplied when creating the client object it must override the Env variable
+func TestClientParamApiHost(t *testing.T) {
+	resetEnv(t)
+	os.Setenv(EnvVarApigeeHost, "http://some.api.host")
+	client := Client{ apigeeApiHost: "https://some.other.host"}
+	client.initDefaults()
+	if client.apigeeApiHost != "https://some.other.host" {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	}
+}
+
+// Test Client.Hosts() - When org does not exist Hosts() should return an error and no hosts.
+func TestClientHostError(t *testing.T) {
+	ts := startMockServer()
+	defer ts.Close()
+
+	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	hosts, err := client.Hosts("not-an-org", "env")
+	if err == nil {
+		t.Fatalf("Error should be returned when org does not exist.")
+	}
+
+	if len(hosts) != 0 {
+		t.Fatalf("Expected aliases length to be 0 is %d", len(hosts))
+	}
+}
+
+// When apigeeApiHost is not supplied and no Env var is set, apigeeApiHost should be default val
+func TestClientDefaultApiHost(t *testing.T) {
+	resetEnv(t)
+	client := Client{}
+	client.initDefaults()
+	if client.apigeeApiHost != DefaultApigeeHost {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	}
+}
+
+// Starts mock httptest server thar returns the used apigee resources, all other resources return 404
+func startMockServer() *httptest.Server {
+	var jsonHostAliasesResp = `{
+    "hostAliases" : [ "org-env.apigee.net", "api.example.com" ],
+    "interfaces" : [ ],
+    "listenOptions" : [ ],
+    "name" : "default",
+    "port" : "80"
+  }`
+
+	var jsonSecureHostAliasesResp = `{
+    "hostAliases" : [ "org-env.apigee.net", "secure.api.example.com" ],
+    "interfaces" : [ ],
+    "listenOptions" : [ ],
+    "name" : "default",
+    "port" : "80"
+  }`
+	
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/organizations/org/environments/env/virtualhosts/default" {
+			fmt.Fprintln(w, jsonHostAliasesResp)
+		} else if r.URL.Path == "/v1/organizations/org/environments/env/virtualhosts/secure" {
+			fmt.Fprintln(w, jsonSecureHostAliasesResp)
+		} else if r.URL.Path == "/v1/organizations/org/environments/env/virtualhosts" {
+			fmt.Fprintln(w, "[\"default\",\"secure\"]")
+		} else {
+			w.WriteHeader(404)
+		}
+	}))
+
+	return ts
+}
+
+// Reset all used Env variables
+func resetEnv(t *testing.T) {
+	unsetEnv := func(name string) {
+		err := os.Unsetenv(name)
+
+		if err != nil {
+			t.Fatalf("Unable to unset environment variable (%s): %v\n", name, err)
+		}
+	}
+
+	unsetEnv(EnvVarApigeeHost)
+}
+

--- a/pkg/apigee/apigee_test.go
+++ b/pkg/apigee/apigee_test.go
@@ -15,7 +15,7 @@ func TestClientHosts(t *testing.T) {
 	ts := startMockServer()
 	defer ts.Close()
 
-	client := Client{ token: "<token>", apigeeApiHost: ts.URL + "/" }
+	client := Client{ Token: "<token>", ApigeeApiHost: ts.URL + "/" }
 	hosts, err := client.Hosts("org", "env")
 	if err != nil {
 		t.Fatalf("Error when calling Hosts: %v.", err)
@@ -44,7 +44,7 @@ func TestClienthostAliases(t *testing.T) {
 	ts := startMockServer()
 	defer ts.Close()
 
-	client := Client{ token: "<token>", apigeeApiHost: ts.URL + "/" }
+	client := Client{ Token: "<token>", ApigeeApiHost: ts.URL + "/" }
 	aliases, err := client.hostAliases("org", "env", "default")
 	if err != nil {
 		t.Fatalf("Error when calling hostAliases: %v.", err)
@@ -69,8 +69,8 @@ func TestClientEnvApiHost(t *testing.T) {
 	os.Setenv(EnvVarApigeeHost, "http://some.api.host/")
 	client := Client{}
 	client.initDefaults()
-	if client.apigeeApiHost != "http://some.api.host/" {
-		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	if client.ApigeeApiHost != "http://some.api.host/" {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.ApigeeApiHost)
 	}
 }
 
@@ -78,10 +78,10 @@ func TestClientEnvApiHost(t *testing.T) {
 func TestClientParamApiHost(t *testing.T) {
 	resetEnv(t)
 	os.Setenv(EnvVarApigeeHost, "http://some.api.host/")
-	client := Client{ apigeeApiHost: "https://some.other.host/"}
+	client := Client{ ApigeeApiHost: "https://some.other.host/"}
 	client.initDefaults()
-	if client.apigeeApiHost != "https://some.other.host/" {
-		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	if client.ApigeeApiHost != "https://some.other.host/" {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.ApigeeApiHost)
 	}
 }
 
@@ -90,7 +90,7 @@ func TestClientHostError(t *testing.T) {
 	ts := startMockServer()
 	defer ts.Close()
 
-	client := Client{ token: "<token>", apigeeApiHost: ts.URL }
+	client := Client{ Token: "<token>", ApigeeApiHost: ts.URL }
 	hosts, err := client.Hosts("not-an-org", "env")
 	if err == nil {
 		t.Fatalf("Error should be returned when org does not exist.")
@@ -106,8 +106,8 @@ func TestClientDefaultApiHost(t *testing.T) {
 	resetEnv(t)
 	client := Client{}
 	client.initDefaults()
-	if client.apigeeApiHost != DefaultApigeeHost {
-		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.apigeeApiHost)
+	if client.ApigeeApiHost != DefaultApigeeHost {
+		t.Fatalf("client.apigeeApiHost did not match expected was %s", client.ApigeeApiHost)
 	}
 }
 


### PR DESCRIPTION
Implements issue #88 

- Includes `pkg/apigee` with `Client.Hosts(org, env, token)` to get hosts from apigee.
- Server exposes a PATCH resource on `/environments/{org}:{env}` that updates the `hostNames` annotation from the values in Apigee api.
- When creating an environment get hosts from Apigee instead of user supplied.
- `AUTH_API_HOST` Expects url schema and a ending forward slash. Defaults to `https://api.enterprise.apigee.com/`