### PR TITLE
Use local kube config for kube api access

### DIFF
--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"k8s.io/kubernetes/pkg/client/restclient"
-
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
@@ -24,7 +24,16 @@ func Init(clientConfig restclient.Config) error {
 
 		//Local Config
 	} else {
-		tempClient, err := k8sClient.New(&clientConfig)
+
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		configOverrides := &clientcmd.ConfigOverrides{}
+		config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+		tmpKubeConfig, err := config.ClientConfig()
+		if err != nil {
+			return err
+		}
+
+		tempClient, err := k8sClient.New(tmpKubeConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Uses the builtins from the kubernetes client to grab api configuration from the .kube settings. Same as https://github.com/30x/k8s-router/pull/47