### PR TITLE
Dispatcher compatability

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: enrober
-        image: thirtyx/enrober:testing3
+        image: thirtyx/enrober:testing12
         env:
           - name: DEPLOY_STATE
             value: "PROD"
@@ -24,6 +24,8 @@ spec:
             value: "false"
           - name: APIGEE_KVM
             value: "true"
+          - name: PTS_URL_HOST_RESTRICTION
+            value: "false"
         ports:
           - containerPort: 9000
 

--- a/pkg/apigee/apigee.go
+++ b/pkg/apigee/apigee.go
@@ -230,6 +230,8 @@ func (c *Client) CPSEnabledForOrg(orgName string) (bool, error) {
 }
 
 func (c *Client) CreateKVM(orgName, envName, publicKey string) error {
+	c.initDefaults()
+
 	const apigeeKVMName = "shipyard-routing"
 	const apigeeKVMPKName = "x-routing-api-key"
 

--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/pkg/api/v1"
+	"os"
 )
 
 func TestGenerateRandomBytes(t *testing.T) {
@@ -29,6 +30,7 @@ func TestGenerateRandomString(t *testing.T) {
 }
 
 func TestGetPTSFromURL(t *testing.T) {
+	os.Setenv("PTS_URL_HOST_RESTRICTION", "false")
 	ts := startMockServer()
 
 	mockRequest := http.Request{}

--- a/pkg/helper/ptsURL.go
+++ b/pkg/helper/ptsURL.go
@@ -32,8 +32,7 @@ func GetPTSFromURL(ptsURLString string, request *http.Request) (v1.PodTemplateSp
 		return v1.PodTemplateSpec{}, errors.New(errorMessage)
 	}
 
-	//This could be moved up
-	if os.Getenv("DEPLOY_STATE") == "PROD" {
+	if os.Getenv("PTS_URL_HOST_RESTRICTION") != "false" {
 		u, err := url.Parse(ptsURLString)
 		if err != nil {
 			errorMessage := fmt.Sprintf("Error parsing ptsURL: %s\n", err)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -226,11 +226,10 @@ func createDeployment(w http.ResponseWriter, r *http.Request) {
 
 	if tempJSON.Paths == nil {
 		//Make default paths
-		tempInt := int32(9000)
 		tempPath := []EdgePath{
 			{
 				BasePath:      "/" + tempJSON.DeploymentName,
-				ContainerPort: &tempInt,
+				ContainerPort: "9000",
 			},
 		}
 		err, tempPTS.Annotations["edge/paths"] = composePathsJSON(tempPath)
@@ -276,6 +275,9 @@ func createDeployment(w http.ResponseWriter, r *http.Request) {
 	parsedImage := strings.Split(tempPTS.Spec.Containers[0].Image, ":")
 	if len(parsedImage) == 3 {
 		tempPTS.Labels["edge/app.rev"] = parsedImage[2]
+	} else {
+		//DEFAULT for now
+		tempPTS.Labels["edge/app.rev"] = "1"
 	}
 
 	//Could also use proto package

--- a/pkg/server/helper_test.go
+++ b/pkg/server/helper_test.go
@@ -36,11 +36,10 @@ func TestParseHoststoMap(t *testing.T) {
 }
 
 func TestComposePaths(t *testing.T) {
-	tempInt := int32(9000)
 	mockPathsObj := []EdgePath{
 		{
 			BasePath:      "base",
-			ContainerPort: &tempInt,
+			ContainerPort: "9000",
 			TargetPath:    "target",
 		},
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,10 +18,6 @@ import (
 //Global Vars
 var (
 
-	//Global Regex
-	validIPAddressRegex = regexp.MustCompile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
-	validHostnameRegex  = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
-
 	//Env Name Regex
 	envNameRegex = regexp.MustCompile(`\w+\:\w+`)
 
@@ -35,6 +31,8 @@ var (
 	apigeeKVM bool
 
 	apigeeAPIHost string
+
+	PtsHostRestriction bool
 
 	clientset kubernetes.Clientset
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,8 +32,6 @@ var (
 
 	apigeeAPIHost string
 
-	PtsHostRestriction bool
-
 	clientset kubernetes.Clientset
 )
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"os"
 )
 
 var _ = Describe("Server Test", func() {
@@ -35,7 +36,7 @@ var _ = Describe("Server Test", func() {
     			"replicas": 1,
     			"edgePaths": [{
     				"basePath": "base",
-    				"containerPort": 9000,
+    				"containerPort": "9000",
     				"targetPath": "target"
 				}],
     			"ptsURL": "https://api.myjson.com/bins/2p9z1",
@@ -65,7 +66,7 @@ var _ = Describe("Server Test", func() {
 				"replicas": 3,
 				"edgePaths": [{
     				"basePath": "base",
-    				"containerPort": 9000,
+    				"containerPort": "9000",
     				"targetPath": "target"
 				}],
 				"ptsURL": "https://api.myjson.com/bins/119h9",
@@ -166,6 +167,7 @@ var _ = Describe("Server Test", func() {
 
 	Context("Local Testing", func() {
 		server, hostBase, err := setup()
+		os.Setenv("PTS_URL_HOST_RESTRICTION", "false")
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to start server %s", err))
 		}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -30,7 +30,7 @@ type HostsConfig struct {
 
 type EdgePath struct {
 	BasePath      string `json:"basePath"`
-	ContainerPort *int32 `json:"containerPort"`
+	ContainerPort string `json:"containerPort"`
 	TargetPath    string `json:"targetPath,omitempty"`
 }
 


### PR DESCRIPTION
Makes `enrober` compatible with dispatcher for Edge centric deployment. 

Resolves #96 too