### PR TITLE
Enable PORT environment variable on created containers

### DIFF
--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -185,6 +185,8 @@ func createDeployment(w http.ResponseWriter, r *http.Request) {
 		helper.LogError.Printf(errorMessage)
 		return
 	}
+	//DEBUG
+	fmt.Printf("TempJSON: %v\n", tempJSON)
 
 	//Check if deployment with given name already exists
 	_, err = clientset.Deployments(pathVars["org"] + "-" + pathVars["env"]).Get(tempJSON.DeploymentName)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -185,8 +185,6 @@ func createDeployment(w http.ResponseWriter, r *http.Request) {
 		helper.LogError.Printf(errorMessage)
 		return
 	}
-	//DEBUG
-	fmt.Printf("TempJSON: %v\n", tempJSON)
 
 	//Check if deployment with given name already exists
 	_, err = clientset.Deployments(pathVars["org"] + "-" + pathVars["env"]).Get(tempJSON.DeploymentName)

--- a/pkg/server/helper.go
+++ b/pkg/server/helper.go
@@ -306,21 +306,21 @@ func validatePath(path string) bool {
 	return true
 }
 
-//TODO: Unit test this
 func multipleEdgePorts(paths []EdgePath) bool {
 	if len(paths) <= 1 {
 		return false
 	}
 	m := map[string]bool{}
 	for i, val := range paths {
-		//Add the value to map
-		m[val.ContainerPort] = true
 		if i != 0 {
-			if _, seen := m[val.ContainerPort]; !seen {
+			_, seen := m[val.ContainerPort]
+			if !seen {
 				//Got a new port so return true
 				return true
 			}
 		}
+		//Add the value to map only after we've checked it doesn't have new port
+		m[val.ContainerPort] = true
 	}
 	return false
 }

--- a/pkg/server/helper.go
+++ b/pkg/server/helper.go
@@ -81,7 +81,6 @@ func GeneratePTS(depBody deploymentPost, org, env string) (v1.PodTemplateSpec, e
 	}
 	tempK8sEnv = append(tempK8sEnv, apiKeyEnv)
 
-	//TODO: Pass and Fail test case for this
 	//Default port env var
 	var portEnvVar v1.EnvVar
 

--- a/pkg/server/helper.go
+++ b/pkg/server/helper.go
@@ -52,6 +52,11 @@ func GeneratePTS(depBody deploymentPost, org, env string) (v1.PodTemplateSpec, e
 		}
 	} else {
 		var err error
+		//Check to make sure we weren't given an array of edgePaths with multiple different ports
+		if multipleEdgePorts(depBody.Paths) {
+			err = errors.New("Multiple Ports given")
+			return v1.PodTemplateSpec{}, err
+		}
 		intPort, err = strconv.Atoi(depBody.Paths[0].ContainerPort)
 		tempPaths, err = composePathsJSON(depBody.Paths)
 		if err != nil {
@@ -76,6 +81,21 @@ func GeneratePTS(depBody deploymentPost, org, env string) (v1.PodTemplateSpec, e
 	}
 	tempK8sEnv = append(tempK8sEnv, apiKeyEnv)
 
+	//TODO: Pass and Fail test case for this
+	//Default port env var
+	var portEnvVar v1.EnvVar
+
+	//If no edgePaths are given set default to 9000
+	if depBody.Paths == nil {
+		portEnvVar.Name = "PORT"
+		portEnvVar.Value = "9000"
+	} else {
+		//Else set it to the given containerPort in edgePaths
+		portEnvVar.Name = "PORT"
+		portEnvVar.Value = depBody.Paths[0].ContainerPort
+	}
+	tempK8sEnv = append(tempK8sEnv, portEnvVar)
+
 	tempPTS := v1.PodTemplateSpec{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
@@ -99,6 +119,7 @@ func GeneratePTS(depBody deploymentPost, org, env string) (v1.PodTemplateSpec, e
 					Image:           tempURI + "/" + org + "/" + depBody.DeploymentName + ":" + strconv.Itoa(int(depBody.Revision)),
 					ImagePullPolicy: v1.PullAlways,
 					//Ensures that containers do not have privileged access
+					//The weird lambda thing just gives a pointer to a bool set to false (because proto)
 					SecurityContext: &v1.SecurityContext{
 						Privileged: func() *bool { b := false; return &b }(),
 					},
@@ -283,4 +304,23 @@ func validatePath(path string) bool {
 		}
 	}
 	return true
+}
+
+//TODO: Unit test this
+func multipleEdgePorts(paths []EdgePath) bool {
+	if len(paths) <= 1 {
+		return false
+	}
+	m := map[string]bool{}
+	for i, val := range paths {
+		//Add the value to map
+		m[val.ContainerPort] = true
+		if i != 0 {
+			if _, seen := m[val.ContainerPort]; !seen {
+				//Got a new port so return true
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/server/helper_test.go
+++ b/pkg/server/helper_test.go
@@ -63,15 +63,60 @@ func TestValidatePath(t *testing.T) {
 	testPathPass := "/test/%2a/aa/a"
 
 	if validatePath(testNoPrefix) == true {
-		t.Fatalf("Expected false got true")
+		t.Fatal("Expected false got true")
 	}
 
 	if validatePath(testPathFail) == true {
-		t.Fatalf("Expected false got true")
+		t.Fatal("Expected false got true")
 	}
 
 	if validatePath(testPathPass) == false {
-		t.Fatalf("Expected true got false")
+		t.Fatal("Expected true got false")
+	}
+
+}
+
+func TestMultipleEdgePorts(t *testing.T) {
+	singularPortPaths := []EdgePath{
+		{
+			BasePath:      "/test1",
+			ContainerPort: "9000",
+			TargetPath:    "/",
+		},
+		{
+			BasePath:      "/test2",
+			ContainerPort: "9000",
+			TargetPath:    "/2",
+		},
+		{
+			BasePath:      "/test3",
+			ContainerPort: "9000",
+			TargetPath:    "/3",
+		},
+	}
+	if multipleEdgePorts(singularPortPaths) {
+		t.Fatal("Expected false got true")
+	}
+
+	multiplePortPaths := []EdgePath{
+		{
+			BasePath:      "/test1",
+			ContainerPort: "9000",
+			TargetPath:    "/",
+		},
+		{
+			BasePath:      "/test2",
+			ContainerPort: "3000",
+			TargetPath:    "/2",
+		},
+		{
+			BasePath:      "/test3",
+			ContainerPort: "9000",
+			TargetPath:    "/3",
+		},
+	}
+	if !multipleEdgePorts(multiplePortPaths) {
+		t.Fatal("Expected true got false")
 	}
 
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,21 +92,22 @@ func init() {
 		}
 		clientset = *tempClientset
 
-		//Local Config
 	} else {
+		//Local Config
+
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		configOverrides := &clientcmd.ConfigOverrides{}
 		config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 		tmpConfig, err := config.ClientConfig()
 		if err != nil {
-			fmt.Printf("Error on init: %v\n", err)
-			return
+			fmt.Printf("Error on init, creating Client Config: %v\n", err)
+			panic(err)
 		}
 		//Create the clientset
 		tempClientset, err := kubernetes.NewForConfig(tmpConfig)
 		if err != nil {
-			fmt.Printf("Error on init: %v\n", err)
-			return
+			fmt.Printf("Error on init, creating Clientset: %v\n", err)
+			panic(err)
 		}
 		clientset = *tempClientset
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -28,6 +28,36 @@ var _ = Describe("Server Test", func() {
 			Expect(resp.StatusCode).Should(Equal(200), "Response should be 200")
 		})
 
+		It("Create Deployment with Multiple Ports", func() {
+			url := fmt.Sprintf("%s/environments/thirtyx:test/deployments", hostBase)
+
+			jsonStr := []byte(`{
+				"deploymentName": "nodejs-k8s-env",
+    			"replicas": 1,
+    			"edgePaths": [{
+	    			"basePath": "/base",
+    				"containerPort": "3000",
+    				"targetPath": "/target"
+   				},
+    			{
+	    			"basePath": "/base",
+    				"containerPort": "9000",
+    				"targetPath": "/target"
+    			}],
+				"revision": 1,
+				"envVars": [{
+					"name": "test1",
+					"value": "value1"
+				}]
+			}`)
+
+			req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
+
+			resp, _ := client.Do(req)
+
+			Expect(resp.StatusCode).Should(Equal(500), "Should get an error POST")
+		})
+
 		It("Create Deployment", func() {
 			url := fmt.Sprintf("%s/environments/thirtyx:test/deployments", hostBase)
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -51,7 +51,7 @@ type deploymentPost struct {
 type deploymentPatch struct {
 	Paths    []EdgePath            `json:"edgePaths,omitempty"`
 	Replicas *int32                `json:"replicas,omitempty"`
-	Revision *int32                `json:"revision,omitempty`
+	Revision *int32                `json:"revision,omitempty"`
 	EnvVars  []apigee.ApigeeEnvVar `json:"envVars,omitempty"`
 }
 


### PR DESCRIPTION
- Set a PORT env var on container that defaults to 9000 or is set to containerPort of first edgePath
- Will error if array of edgePaths contains multiple different containerPort values.

resolves #129 