### PR TITLE
Fix Path Validation with empty TargetPath

### DIFF
--- a/pkg/server/helper.go
+++ b/pkg/server/helper.go
@@ -297,7 +297,7 @@ func composePathsJSON(paths []EdgePath) (string, error) {
 		if !validatePath(path.BasePath) {
 			return "", errors.New(fmt.Sprintf("Invalid Path: %v", path.BasePath))
 
-		} else if !validatePath(path.TargetPath) {
+		} else if path.TargetPath != "" && !validatePath(path.TargetPath) {
 			return "", errors.New(fmt.Sprintf("Invalid Path: %v", path.TargetPath))
 		}
 	}

--- a/pkg/server/helper_test.go
+++ b/pkg/server/helper_test.go
@@ -57,6 +57,30 @@ func TestComposePaths(t *testing.T) {
 	}
 }
 
+func TestComposePathsNoTargetPath(t *testing.T) {
+	mockPathsObj := []EdgePath{
+		{
+			BasePath:      "/base",
+			ContainerPort: "9000",
+			TargetPath:    "",
+		},
+	}
+	mockJSON :=
+		`[
+  {
+    "basePath": "/base",
+    "containerPort": "9000"
+  }
+]`
+	resultJSON, err := composePathsJSON(mockPathsObj)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if resultJSON != mockJSON {
+		t.Fatalf("Expected\n%v\ngot\n%v", mockJSON, resultJSON)
+	}
+}
+
 func TestValidatePath(t *testing.T) {
 	testNoPrefix := "test"
 	testPathFail := "/test/%2a/%"


### PR DESCRIPTION
After we updated the regex to throw on an empty path it now fails when a api client sends a edgePath with only basePath and containerPort.